### PR TITLE
Added check for empty assembly location

### DIFF
--- a/SourceGeneratorTests/Tests.cs
+++ b/SourceGeneratorTests/Tests.cs
@@ -48,7 +48,7 @@ namespace Foo
             Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
             foreach (var assembly in assemblies)
             {
-                if (!assembly.IsDynamic)
+                if (!assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
                 {
                     references.Add(MetadataReference.CreateFromFile(assembly.Location));
                 }


### PR DESCRIPTION
Using Visual Studio 2019 (preview) test runner and xunit, I encountered blank assembly locations in the tests. This, naturally, blocked testing.

I added a check for this. 

Feel free to take or not take, this was just an easy way to share what I encountered.